### PR TITLE
Feature/version tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Version type support for GitFlow idiom
+
+### Changed
+
+- Renamed `next` command to `unreleased`, `version` command to `next`
+
 ## [0.7.0] - 2021-04-23
 
 ### Added

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,11 +5,11 @@ const (
 	headingTarget = "# Targets"
 
 	// Subcommands
-	cmdTargets = "targets"
-	cmdLatest  = "latest"
-	cmdNext    = "next"
-	cmdTo      = "to"
-	cmdVersion = "version"
+	cmdTargets    = "targets"
+	cmdLatest     = "latest"
+	cmdUnreleased = "unreleased"
+	cmdNext       = "next"
+	cmdTo         = "to"
 
 	// Flag keys
 	flagDirectory   = "dir"

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -16,7 +16,8 @@ func TestRun(t *testing.T) {
 		pats := []string{
 			"",
 			cmdTargets, "target", "t",
-			cmdNext, "n",
+			cmdUnreleased, "u",
+			// cmdNext, "n",
 			cmdTo,
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -50,11 +50,10 @@ func Run(args []string) error {
 		Required: true,
 	}
 
-	versionFlag := &cli.StringFlag{
-		Name:        flagType,
-		Usage:       "Semver `TYPE`: X.Y.Z refers to {major}.{minor}.{patch}",
-		Aliases:     []string{"t"},
-		DefaultText: parser.MinorVersion.String(),
+	typeFlag := &cli.StringFlag{
+		Name:    flagType,
+		Usage:   "Semver `TYPE`: X.Y.Z refers to {major}.{minor}.{patch} or {release}.{feature}.{hotfix}",
+		Aliases: []string{"t"},
 	}
 
 	app := &cli.App{
@@ -105,9 +104,9 @@ func Run(args []string) error {
 				},
 			},
 			{
-				Name:    cmdNext,
+				Name:    cmdUnreleased,
 				Usage:   fmt.Sprintf("List all changes for %s", parser.Unreleased),
-				Aliases: []string{"n"},
+				Aliases: []string{"u"},
 				Flags: []cli.Flag{
 					dirFlag,
 					ignoreEmptyFlag,
@@ -285,12 +284,12 @@ func Run(args []string) error {
 				},
 			},
 			{
-				Name:    cmdVersion,
+				Name:    cmdNext,
 				Usage:   "Suggest next version by checking CHANGELOGs recursively",
-				Aliases: []string{"v"},
+				Aliases: []string{"n"},
 				Flags: []cli.Flag{
 					dirFlag,
-					versionFlag,
+					typeFlag,
 				},
 				Action: func(c *cli.Context) error {
 
@@ -333,14 +332,42 @@ func Run(args []string) error {
 					vers = parser.SortVersions(vers)
 					ver := vers[len(vers)-1]
 
-					fmt.Println("")
-					fmt.Println("Latest released version:", chalk.Magenta.Color(ver.String()))
-					fmt.Println("")
-					fmt.Println("Suggestions for next release:")
-					fmt.Println("   - Major / Release -->", chalk.Magenta.Color((ver.Increment(parser.MajorVersion).String())))
-					fmt.Println("   - Minor / Feature -->", chalk.Magenta.Color(ver.Increment(parser.MinorVersion).String()))
-					fmt.Println("   - Patch / Hotfix  -->", chalk.Magenta.Color(ver.Increment(parser.PatchVersion).String()))
-					fmt.Println("")
+					tflag := c.String(flagType)
+
+					if tflag == "" {
+						fmt.Println("")
+						fmt.Println("Latest released version:", chalk.Magenta.Color(ver.String()))
+						fmt.Println("")
+						fmt.Println("Suggestions for next release:")
+						fmt.Println("   - Major / Release -->", chalk.Magenta.Color((ver.Increment(parser.MajorVersion).String())))
+						fmt.Println("   - Minor / Feature -->", chalk.Magenta.Color(ver.Increment(parser.MinorVersion).String()))
+						fmt.Println("   - Patch / Hotfix  -->", chalk.Magenta.Color(ver.Increment(parser.PatchVersion).String()))
+						fmt.Println("")
+
+						return nil
+					}
+
+					vtype, err := parser.AliasedVersion(tflag)
+
+					if err != nil {
+						fmt.Println(err)
+						os.Exit(1)
+					}
+
+					switch vtype {
+
+					case parser.MajorVersion:
+						fmt.Println(ver.Increment(parser.MajorVersion).String())
+						return nil
+
+					case parser.MinorVersion:
+						fmt.Println(ver.Increment(parser.MinorVersion).String())
+						return nil
+
+					case parser.PatchVersion:
+						fmt.Println(ver.Increment(parser.PatchVersion).String())
+						return nil
+					}
 
 					return nil
 				},

--- a/parser/versiontype.go
+++ b/parser/versiontype.go
@@ -1,5 +1,7 @@
 package parser
 
+import "errors"
+
 // VersionType corresponds to Major.Minor.Patch in Semantic Versioning 2.0.0.
 // https://semver.org
 type VersionType string
@@ -15,3 +17,22 @@ const (
 	MinorVersion VersionType = "minor"
 	PatchVersion VersionType = "patch"
 )
+
+// AliasedVersion returns the original version type or error.
+// GitFlow idiom is currently available.
+func AliasedVersion(in string) (VersionType, error) {
+
+	switch in {
+
+	case MajorVersion.String(), "release":
+		return MajorVersion, nil
+
+	case MinorVersion.String(), "feature":
+		return MinorVersion, nil
+
+	case PatchVersion.String(), "hotfix":
+		return PatchVersion, nil
+	}
+
+	return "", errors.New("given alias is not in list")
+}

--- a/parser/versiontype_test.go
+++ b/parser/versiontype_test.go
@@ -5,9 +5,73 @@ import (
 
 	"release/parser"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionTypeString(t *testing.T) {
 	assert.Equal(t, string(parser.MajorVersion), parser.MajorVersion.String())
+}
+
+func TestAliasedVersion(t *testing.T) {
+	{
+		// Success cases, MajorVersion
+		pats := []string{
+			parser.MajorVersion.String(),
+			"release",
+		}
+
+		for _, p := range pats {
+			got, err := parser.AliasedVersion(p)
+
+			require.NoErrorf(t, err, spew.Sdump(p))
+			assert.Equal(t, parser.MajorVersion, got, spew.Sdump(p, got))
+		}
+	}
+
+	{
+		// Success cases, MinorVersion
+		pats := []string{
+			parser.MinorVersion.String(),
+			"feature",
+		}
+
+		for _, p := range pats {
+			got, err := parser.AliasedVersion(p)
+
+			require.NoErrorf(t, err, spew.Sdump(p))
+			assert.Equal(t, parser.MinorVersion, got, spew.Sdump(p, got))
+		}
+	}
+
+	{
+		// Success cases, PatchVersion
+		pats := []string{
+			parser.PatchVersion.String(),
+			"hotfix",
+		}
+
+		for _, p := range pats {
+			got, err := parser.AliasedVersion(p)
+
+			require.NoErrorf(t, err, spew.Sdump(p))
+			assert.Equal(t, parser.PatchVersion, got, spew.Sdump(p, got))
+		}
+	}
+
+	{
+		// Fail cases
+		pats := []string{
+			"",
+			"foo",
+		}
+
+		for _, p := range pats {
+			got, err := parser.AliasedVersion(p)
+
+			require.Errorf(t, err, spew.Sdump(p))
+			assert.Empty(t, got, spew.Sdump(p, got))
+		}
+	}
 }


### PR DESCRIPTION
### Added

- Version type support for GitFlow idiom

### Changed

- Renamed `next` command to `unreleased`, `version` command to `next`