### PR TITLE
No newline on version type rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- No newline on version type rendering
 - Renamed `next` command to `unreleased`, `version` command to `next`
 
 ## [0.7.0] - 2021-04-23

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -357,15 +357,15 @@ func Run(args []string) error {
 					switch vtype {
 
 					case parser.MajorVersion:
-						fmt.Println(ver.Increment(parser.MajorVersion).String())
+						fmt.Print(ver.Increment(parser.MajorVersion).String())
 						return nil
 
 					case parser.MinorVersion:
-						fmt.Println(ver.Increment(parser.MinorVersion).String())
+						fmt.Print(ver.Increment(parser.MinorVersion).String())
 						return nil
 
 					case parser.PatchVersion:
-						fmt.Println(ver.Increment(parser.PatchVersion).String())
+						fmt.Print(ver.Increment(parser.PatchVersion).String())
 						return nil
 					}
 


### PR DESCRIPTION
Tweaked rendering not to insert newline (carriage return) after `release next -t major` run.
This way, the real world applications could integrate `release` in any inline script (e.g. bash), and does not need to consider trimming the newline.

## Previously

```
$ go run main.go next -t major
1.0.0
$
```

## Now

```
$ go run main.go next -t major
1.0.0$
```