### PR TITLE
Implemented --any flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-07-14
+
+### Added
+
+- Added darwin/arm64 build
+- Implemented --any flag
+
 ## [0.8.2] - 2021-07-14
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build: clean
 	@echo "Building.."
 	gox -output="$(BUILD)/{{.Dir}}_{{.OS}}_{{.Arch}}" \
 		-osarch="darwin/amd64" \
+		-osarch="darwin/arm64" \
 		-osarch="linux/arm" \
 		-osarch="linux/amd64" \
 		-osarch="windows/amd64"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -12,6 +12,7 @@ const (
 	cmdTo         = "to"
 
 	// Flag keys
+	flagAny         = "any"
 	flagDirectory   = "dir"
 	flagIgnoreEmpty = "ignore"
 	flagVersion     = "version"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,6 +22,13 @@ func Run(args []string) error {
 		log.Fatal(err)
 	}
 
+	anyFlag := &cli.BoolFlag{
+		Name:    flagAny,
+		Value:   false,
+		Usage:   "ignore semantic versioning and grab anything inside [string]",
+		Aliases: []string{"a"},
+	}
+
 	dirFlag := &cli.StringFlag{
 		Name:    flagDirectory,
 		Value:   wd,
@@ -82,6 +89,7 @@ func Run(args []string) error {
 				Usage:   "Show the latest released version in current directory",
 				Aliases: []string{"l"},
 				Flags: []cli.Flag{
+					anyFlag,
 					dirFlag,
 				},
 				Action: func(c *cli.Context) error {
@@ -90,6 +98,18 @@ func Run(args []string) error {
 
 					if err != nil {
 						return err
+					}
+
+					if c.Bool(flagAny) {
+						got, err := parser.LatestAny(doc)
+
+						if err != nil {
+							return err
+						}
+
+						fmt.Println(got)
+
+						return nil
 					}
 
 					got, err := parser.Latest(doc)

--- a/files/glob_test.go
+++ b/files/glob_test.go
@@ -41,7 +41,7 @@ func TestGlob(t *testing.T) {
 		pats := []pattern{
 			{
 				path:  fmt.Sprintf("%s/test", pwd),
-				count: 4,
+				count: 5,
 			},
 			{
 				path:  fmt.Sprintf("%s/test/some", pwd),

--- a/files/test/any/CHANGELOG.md
+++ b/files/test/any/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Foo
+
+## [just-a-demo:123]
+
+### Added
+
+- Bar

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -148,3 +148,32 @@ func Latest(doc string) (string, error) {
 
 	return "", errors.New("not found")
 }
+
+// LatestAny returns the latest [version] stored in document.
+// Unlike `Latest` which follows Semantic Versioning, this function parse arbitary string
+// excluding `## [Unreleased]` and string with blank spaces.
+// This operation simply matches to the first h2 header.
+func LatestAny(doc string) (string, error) {
+
+	re := regexp.MustCompile(`## \[(.*)\]`)
+
+	for _, line := range strings.Split(doc, "\n") {
+		got := re.FindStringSubmatch(line)
+
+		if len(got) != 2 {
+			continue
+		}
+
+		if got[1] == "Unreleased" {
+			continue
+		}
+
+		if strings.Contains(got[1], " ") {
+			continue
+		}
+
+		return got[1], nil
+	}
+
+	return "", errors.New("not found")
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -260,3 +260,86 @@ func TestLatest(t *testing.T) {
 		}
 	}
 }
+
+func TestLatestAny(t *testing.T) {
+	type pattern struct {
+		doc      string
+		expected string
+	}
+
+	{
+		// Success cases.
+		pats := []pattern{
+			{
+				doc: strings.Join([]string{
+					"## [1.2.3]",
+				}, "\n"),
+				expected: "1.2.3",
+			},
+			{
+				doc: strings.Join([]string{
+					"## [100.200.300]",
+				}, "\n"),
+				expected: "100.200.300",
+			},
+			{
+				doc: strings.Join([]string{
+					"## [Unreleased]",
+					"## [1.2.3]",
+					"hello",
+					"## [1.2.3]",
+					"hello",
+				}, "\n"),
+				expected: "1.2.3",
+			},
+			{
+				doc: strings.Join([]string{
+					"## [Unreleased]",
+					"## [node-alpine:123]",
+				}, "\n"),
+				expected: "node-alpine:123",
+			},
+			{
+				doc: strings.Join([]string{
+					"## [Unreleased]",
+					"## [Node-Alpine:123]",
+				}, "\n"),
+				expected: "Node-Alpine:123",
+			},
+		}
+
+		for _, p := range pats {
+			got, err := parser.LatestAny(p.doc)
+
+			require.Nil(t, err)
+			assert.Equal(t, p.expected, got)
+		}
+	}
+
+	{
+		// Fail cases.
+		pats := []pattern{
+			{
+				doc: strings.Join([]string{}, "\n"),
+			},
+			{
+				doc: strings.Join([]string{
+					"# Hello",
+					"## Unreleased",
+				}, "\n"),
+			},
+			{
+				doc: strings.Join([]string{
+					"# Hello",
+					"## [contains blank]",
+				}, "\n"),
+			},
+		}
+
+		for _, p := range pats {
+			_, err := parser.LatestAny(p.doc)
+
+			require.NotNil(t, err)
+		}
+	}
+}


### PR DESCRIPTION
The `release` cli was intended to parse changelogs with Semantic Versioning, but majority of Docker Images have custom formatted string like `node8-alpine:123`.

This PR will adds `--any` flag to parse any formats.