### PR TITLE
Added Github-style `vX.Y.Z` semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Use `--newline` flag if you prefer to see the newline.
     release next --type hotfix
     0.8.1
 
+### Github-style semver `vx.y.z`
+
+The tool also supports [Github-style semver](https://semver.org/#is-v123-a-semantic-version):
+
+    release show -v v0.1.0
+    release to -v v0.2.0
+
 ## Development
 
 ### Run

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,13 +20,24 @@ const (
 // Version transforms 0.1.0 to [0.1.0].
 // Returns error when given input is not following SemVar.
 func Version(in string) (string, error) {
+	githubStyleSemver := false
+
+	if len(in) > 0 && in[0] == 'v' {
+		in = in[1:]
+		githubStyleSemver = true
+	}
+
 	v, err := semver.Make(in)
 
 	if err != nil {
 		return "", errors.New("given version is not compatible with Semantic Versioning")
 	}
 
-	return fmt.Sprintf("[%s]", v.String()), nil
+	if githubStyleSemver == true {
+		return fmt.Sprintf("[v%s]", v.String()), nil
+	} else {
+		return fmt.Sprintf("[%s]", v.String()), nil
+	}
 }
 
 // To returns document replaced with given version.
@@ -135,7 +146,7 @@ func Show(doc string, ver string) ([]string, error) {
 // This operation simply matches to the first h2 header.
 func Latest(doc string) (string, error) {
 
-	re := regexp.MustCompile(`## \[(\d*\.\d*\.\d*)\]`)
+	re := regexp.MustCompile(`## \[([v]?\d*\.\d*\.\d*)\]`)
 
 	for _, line := range strings.Split(doc, "\n") {
 		got := re.FindStringSubmatch(line)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -18,6 +18,7 @@ func TestOpenRepository(t *testing.T) {
 			"0.1.0",
 			"0.1.0-beta",
 			"100.200.300",
+			"v1.2.3",
 		}
 
 		for _, p := range pats {

--- a/parser/semver.go
+++ b/parser/semver.go
@@ -103,6 +103,12 @@ func (c SemanticVersion) Increment(in VersionType) SemanticVersion {
 func CastVersion(name, val string) (int, error) {
 	const failcode = -1
 
+	if name == "major" {
+		if val[0] == 'v' {
+			val = val[1:]
+		}
+	}
+
 	i, err := strconv.Atoi(val)
 
 	if err != nil {

--- a/parser/semver_test.go
+++ b/parser/semver_test.go
@@ -22,7 +22,6 @@ var (
 		"1.2.3a",
 		"1 2 3",
 		"v100",
-		"v1.2.3",
 		"v1.20",
 		"1.20.a",
 		"🍎",
@@ -49,6 +48,10 @@ func TestNewSemanticVersion(t *testing.T) {
 			{
 				expected: parser.SemanticVersion{Major: 123, Minor: 456, Patch: 789},
 				sample:   "123.456.789",
+			},
+			{
+				expected: parser.SemanticVersion{Major: 1, Minor: 2, Patch: 3},
+				sample:   "v1.2.3",
 			},
 		}
 


### PR DESCRIPTION
Original behaviour is maintained, but also supports using `vX.Y.X` type semver format.